### PR TITLE
component: support muxing from different received streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ keywords = ["STUN", "ICE"]
 
 [dependencies]
 log = "0.4"
-byteorder = "1.3.4"
+byteorder = "1"
 env_logger = "0.7"
 get_if_addrs = "0.5"
-async-std = "1.6"
-async-channel = "1.4"
+async-std = "1"
+async-channel = "1"
 rand = "0.7"
 futures = "0.3"
-futures-timer = "3.0.2"
+futures-timer = "3"
 crc = "1"
 sha-1 = "0.9"
 hmac = "0.9"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -11,7 +11,6 @@ use std::fmt::Display;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
-use futures;
 use futures::prelude::*;
 use rand::prelude::*;
 
@@ -36,6 +35,7 @@ pub enum AgentError {
     ConnectionClosed,
     IntegrityCheckFailed,
     Aborted,
+    TimedOut,
     IoError(std::io::Error),
 }
 

--- a/src/bin/icegather.rs
+++ b/src/bin/icegather.rs
@@ -8,7 +8,6 @@
 
 #[macro_use]
 extern crate log;
-use env_logger;
 
 use async_std::task;
 

--- a/src/bin/stunclient.rs
+++ b/src/bin/stunclient.rs
@@ -10,7 +10,6 @@ use std::net::UdpSocket;
 
 #[macro_use]
 extern crate log;
-use env_logger;
 
 use librice::stun::message::*;
 

--- a/src/bin/stund.rs
+++ b/src/bin/stund.rs
@@ -16,7 +16,6 @@ use async_std::task;
 
 #[macro_use]
 extern crate log;
-use env_logger;
 
 use futures::StreamExt;
 

--- a/src/candidate.rs
+++ b/src/candidate.rs
@@ -77,7 +77,7 @@ impl CandidatePair {
     }
 
     pub(crate) fn get_foundation(&self) -> String {
-        return self.local.foundation.to_string() + ":" + &self.remote.foundation;
+        self.local.foundation.to_string() + ":" + &self.remote.foundation
     }
 
     pub fn priority(&self, are_controlling: bool) -> u64 {

--- a/src/component.rs
+++ b/src/component.rs
@@ -92,12 +92,14 @@ impl Component {
     }
 
     // XXX: temporary for bring up
+    #[allow(clippy::await_holding_lock)] /* !!! FIXME !!! */
     pub async fn set_local_addr(&self, addr: SocketAddr) -> Result<(), AgentError> {
         let mut inner = self.inner.lock().unwrap();
         inner.set_local_addr(addr).await
     }
 
     // XXX: temporary for bring up
+    #[allow(clippy::await_holding_lock)] /* !!! FIXME !!! */
     pub async fn set_local_channel(
         &self,
         channel: Arc<UdpSocketChannel>,
@@ -107,6 +109,7 @@ impl Component {
     }
 
     // XXX: temporary for bring up
+    #[allow(clippy::await_holding_lock)] /* !!! FIXME !!! */
     pub async fn set_remote_addr(&self, addr: SocketAddr) -> Result<(), AgentError> {
         let mut inner = self.inner.lock().unwrap();
         inner.set_remote_addr(addr).await
@@ -195,7 +198,7 @@ impl Component {
 
         let (abortable, abort_handle) = futures::future::abortable(async move{
             let mut data_recv_stream = agent.data_receive_stream();
-            if let Err(_) = ready_send.send(0).await {
+            if ready_send.send(0).await.is_err() {
                 return;
             }
             while let Some(data) = data_recv_stream.next().await {
@@ -265,7 +268,7 @@ impl ComponentInner {
         async_std::task::spawn(async move {
             let mut recv_stream = channel.receive_stream();
             while let Some(data) = recv_stream.next().await {
-                if let Err(_) = send_channel.send(data.0).await {
+                if send_channel.send(data.0).await.is_err() {
                     break;
                 }
             }

--- a/src/component.rs
+++ b/src/component.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use async_std::net::{SocketAddr, UdpSocket};
 
+use futures::future::AbortHandle;
 use futures::prelude::*;
 use futures::Stream;
 
@@ -127,12 +128,11 @@ impl Component {
     }
 
     /// Retrieve a Stream that produces data sent to this component from a peer
-    pub fn receive_stream(&self) -> Option<impl Stream<Item = Vec<u8>>> {
+    pub fn receive_stream(&self) -> impl Stream<Item = Vec<u8>> {
         let inner = self.inner.lock().unwrap();
         // TODO: this probably may need to be multiplexed from multiple sources on e.g. candidate
         // changes
-        let c = inner.channel.clone();
-        c.and_then(move |c| Some(c.receive_stream()))
+        inner.receive_receive_channel.clone()
     }
 
     /// Send data to the peer using the established communication channel
@@ -188,6 +188,30 @@ impl Component {
             ),
         )
     }
+
+    pub(crate) async fn add_recv_agent(&self, agent: Arc<StunAgent>) -> AbortHandle {
+        let sender = self.inner.lock().unwrap().receive_send_channel.clone();
+        let (ready_send, mut ready_recv) = async_channel::bounded(1);
+
+        let (abortable, abort_handle) = futures::future::abortable(async move{
+            let mut data_recv_stream = agent.data_receive_stream();
+            if let Err(_) = ready_send.send(0).await {
+                return;
+            }
+            while let Some(data) = data_recv_stream.next().await {
+                if let Err(e) = sender.send(data.0).await {
+                    warn!("error receiving {:?}", e);
+                }
+            }
+            debug!("receive loop exited");
+        });
+
+        async_std::task::spawn(abortable);
+
+        ready_recv.next().await.unwrap();
+
+        abort_handle
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -197,6 +221,8 @@ pub(crate) struct ComponentInner {
     //selected_pair: Option<CandidatePair>,
     socket: Option<Arc<UdpSocketChannel>>,
     channel: Option<Arc<SocketChannel>>,
+    receive_send_channel: async_channel::Sender<Vec<u8>>,
+    receive_receive_channel: async_channel::Receiver<Vec<u8>>,
     pub(crate) stun_agent: Option<Arc<StunAgent>>,
     stun_servers: Vec<SocketAddr>,
     turn_servers: Vec<SocketAddr>,
@@ -205,12 +231,15 @@ pub(crate) struct ComponentInner {
 
 impl ComponentInner {
     fn new(id: usize) -> Self {
+        let (recv_s, recv_r) = async_channel::bounded(16);
         Self {
             id,
             state: ComponentState::New,
             //selected_pair: None,
             socket: None,
             channel: None,
+            receive_send_channel: recv_s,
+            receive_receive_channel: recv_r,
             stun_agent: None,
             stun_servers: vec![],
             turn_servers: vec![],
@@ -230,8 +259,17 @@ impl ComponentInner {
         &mut self,
         channel: Arc<UdpSocketChannel>,
     ) -> Result<(), AgentError> {
-        self.socket = Some(channel);
+        self.socket = Some(channel.clone());
         self.state = ComponentState::Connecting;
+        let send_channel = self.receive_send_channel.clone();
+        async_std::task::spawn(async move {
+            let mut recv_stream = channel.receive_stream();
+            while let Some(data) = recv_stream.next().await {
+                if let Err(_) = send_channel.send(data.0).await {
+                    break;
+                }
+            }
+        });
         Ok(())
     }
 
@@ -344,11 +382,42 @@ mod tests {
                 .await
                 .unwrap();
             let data = vec![3; 4];
-            let recv_stream = recv.receive_stream().unwrap();
+            let recv_stream = recv.receive_stream();
             futures::pin_mut!(recv_stream);
             send.send(&data).await.unwrap();
             let res = recv_stream.next().await.unwrap();
             assert_eq!(data, res);
+        });
+    }
+
+    #[test]
+    fn muxing_recv() {
+        // given two sockets ensure sending to either of them produces the same data
+        init();
+        async_std::task::block_on(async move {
+            let a = Agent::default();
+            let s = a.add_stream();
+            let send = s.add_component().unwrap();
+
+            let socket1 = UdpSocket::bind("127.0.0.1:0".parse::<SocketAddr>().unwrap()).await.unwrap();
+            let addr1 = socket1.local_addr().unwrap();
+            let channel1 = Arc::new(UdpSocketChannel::new(socket1));
+            let stun = Arc::new(StunAgent::new(channel1.clone()));
+            send.add_recv_agent(stun).await;
+
+            let socket2 = UdpSocket::bind("127.0.0.1:0".parse::<SocketAddr>().unwrap()).await.unwrap();
+            let addr2 = socket2.local_addr().unwrap();
+            let channel2 = Arc::new(UdpSocketChannel::new(socket2));
+            let stun = Arc::new(StunAgent::new(channel2.clone()));
+            send.add_recv_agent(stun).await;
+
+            let mut recv_stream = send.receive_stream();
+            let buf = vec![0, 1];
+            channel1.send_to(&buf, addr2).await.unwrap();
+            assert_eq!(&recv_stream.next().await.unwrap(), &buf);
+            let buf = vec![2, 3];
+            channel2.send_to(&buf, addr1).await.unwrap();
+            assert_eq!(&recv_stream.next().await.unwrap(), &buf);
         });
     }
 
@@ -398,14 +467,14 @@ mod tests {
 
             // two-way connection has been setup
             let data = vec![3; 4];
-            let recv_recv_stream = recv.receive_stream().unwrap();
+            let recv_recv_stream = recv.receive_stream();
             futures::pin_mut!(recv_recv_stream);
             send.send(&data).await.unwrap();
             let res = recv_recv_stream.next().await.unwrap();
             assert_eq!(data, res);
 
             let data = vec![2; 4];
-            let send_recv_stream = send.receive_stream().unwrap();
+            let send_recv_stream = send.receive_stream();
             futures::pin_mut!(send_recv_stream);
             recv.send(&data).await.unwrap();
             let res = send_recv_stream.next().await.unwrap();

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -72,7 +72,7 @@ impl Stream {
         Self {
             id,
             agent,
-            broadcast: broadcast.clone(),
+            broadcast,
             state: Arc::new(Mutex::new(StreamState::new(id))),
             checklist: Arc::new(ConnCheckList::new()),
         }
@@ -105,7 +105,7 @@ impl Stream {
             .unwrap()
             .0;
         info!("stream {} adding component {}", self.id, index);
-        if let Some(_) = state.components.get(index) {
+        if state.components.get(index).is_some() {
             return Err(AgentError::AlreadyExists);
         }
         while state.components.len() <= index {
@@ -206,7 +206,7 @@ impl Stream {
             .get(index - 1)
             .unwrap_or(&None)
             .as_ref()
-            .map(|e| e.clone())
+            .cloned()
     }
 
     /// Set local ICE credentials for this `Stream`.
@@ -493,7 +493,7 @@ mod tests {
             s.gather_candidates().await.unwrap();
             let local_cands = s.get_local_candidates();
             info!("gathered local candidates {:?}", local_cands);
-            assert!(local_cands.len() > 0);
+            assert!(!local_cands.is_empty());
         });
     }
 
@@ -519,7 +519,7 @@ mod tests {
             ls.gather_candidates().await.unwrap();
             let local_cands = ls.get_local_candidates();
             info!("gathered local candidates {:?}", local_cands);
-            assert!(local_cands.len() > 0);
+            assert!(!local_cands.is_empty());
             rs.gather_candidates().await.unwrap();
             let remote_cands = rs.get_local_candidates();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -99,13 +99,13 @@ where
         for (i, channel) in channels.iter().enumerate() {
             if (channel.filter)(&data) {
                 // XXX: maybe a parallel send?
-                if let Err(_) = channel.sender.send(data.clone()).await {
+                if channel.sender.send(data.clone()).await.is_err() {
                     removed.push(i);
                 }
             }
         }
 
-        if removed.len() > 0 {
+        if !removed.is_empty() {
             trace!("removing {} listeners", removed.len());
             let mut inner = self.senders.lock().unwrap();
             // XXX: may need a cookie value instead of relying on the sizes


### PR DESCRIPTION
As specified in RFC 8445, any data can be sent on any valid pair to allow for aggresive nomination compatibility with the older ICE specification, RFC5245.