### PR TITLE
Implement support for sending/receiving data over a TCP connection alongside the stun data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ async-channel = "1"
 rand = "0.8"
 futures = "0.3"
 futures-timer = "3"
-crc = "1"
+crc = "2"
 sha-1 = "0.9"
-hmac = "0.10"
+hmac = "0.11"
 derivative = "2"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = { version = "0.2", default-features = false, features = ["std", "std-future"] }
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 once_cell = "1"
 nom = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/ystreet/librice"
 
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }
+async-trait = "0.1"
 byteorder = "1"
 get_if_addrs = "0.5"
 async-std = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-futures = { version = "0.2", default-features = false, features = ["std", "std-future"] }
 tracing-subscriber = "0.2"
 once_cell = "1"
+nom = "7"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -174,12 +174,15 @@ impl Agent {
                 // TODO: ICE restart
                 return Ok(());
             }
-            let set = Arc::new(ConnCheckListSet::from_streams(
-                inner.streams.clone(),
-                self.broadcast.clone(),
-                self.tasks.clone(),
-                inner.controlling,
-            ));
+            let set = Arc::new(
+                ConnCheckListSet::builder(
+                    inner.streams.clone(),
+                    self.broadcast.clone(),
+                    self.tasks.clone(),
+                    inner.controlling,
+                )
+                .build(),
+            );
             inner.checklistset = Some(set.clone());
             set
         };

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex};
 use futures::prelude::*;
 use rand::prelude::*;
 
+use crate::candidate::parse::ParseCandidateError;
 use crate::candidate::Candidate;
 use crate::candidate::TransportType;
 use crate::component::{Component, ComponentState};
@@ -39,6 +40,7 @@ pub enum AgentError {
     IntegrityCheckFailed,
     Aborted,
     TimedOut,
+    CandidateParse(ParseCandidateError),
     IoError(std::io::Error),
 }
 
@@ -53,6 +55,12 @@ impl Display for AgentError {
 impl From<std::io::Error> for AgentError {
     fn from(e: std::io::Error) -> Self {
         Self::IoError(e)
+    }
+}
+
+impl From<ParseCandidateError> for AgentError {
+    fn from(e: ParseCandidateError) -> Self {
+        Self::CandidateParse(e)
     }
 }
 

--- a/src/bin/icegather.rs
+++ b/src/bin/icegather.rs
@@ -9,6 +9,7 @@
 #[macro_use]
 extern crate tracing;
 
+use librice::socket::StunChannel;
 use tracing_subscriber::EnvFilter;
 
 use async_std::task;
@@ -32,7 +33,9 @@ fn main() -> io::Result<()> {
 
         let agents = librice::gathering::iface_udp_sockets()
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::ConnectionAborted, e))?
-            .filter_map(|channel| async move { channel.ok().map(StunAgent::new) })
+            .filter_map(|channel| async move {
+                channel.ok().map(|c| StunAgent::new(StunChannel::UdpAny(c)))
+            })
             .collect::<Vec<_>>()
             .await;
 

--- a/src/bin/stund.rs
+++ b/src/bin/stund.rs
@@ -62,6 +62,12 @@ fn handle_stun_or_data(stun_or_data: StunOrData) -> Option<(Message, SocketAddr)
                     }
                     Err(err) => warn!("error: {}", err),
                 }
+            } else {
+                let mut response = Message::new_error(&msg);
+                response
+                    .add_attribute(ErrorCode::new(400, "Bad Request").unwrap())
+                    .unwrap();
+                return Some((response, from));
             }
         }
     }

--- a/src/bin/stund.rs
+++ b/src/bin/stund.rs
@@ -90,7 +90,7 @@ fn main() -> io::Result<()> {
         let tcp_listener = TcpListener::bind("127.0.0.1:3478").await?;
         let mut incoming = tcp_listener.incoming();
         while let Some(Ok(stream)) = incoming.next().await {
-            let tcp_channel = StunChannel::Tcp(StunOnlyTcpChannel::new(stream));
+            let tcp_channel = StunChannel::Tcp(TcpChannel::new(stream));
             let tcp_stun_agent = StunAgent::new(tcp_channel);
             let mut receive_stream = tcp_stun_agent.receive_stream();
 

--- a/src/bin/stund.rs
+++ b/src/bin/stund.rs
@@ -20,7 +20,7 @@ use futures::StreamExt;
 use tracing_subscriber::EnvFilter;
 
 use librice::agent::*;
-use librice::socket::{SocketChannel, TcpChannel, UdpSocketChannel};
+use librice::socket::*;
 use librice::stun::agent::*;
 use librice::stun::attribute::*;
 use librice::stun::message::*;
@@ -75,7 +75,7 @@ fn main() -> io::Result<()> {
 
     task::block_on(async move {
         let udp_socket = UdpSocket::bind("127.0.0.1:3478").await?;
-        let udp_channel = SocketChannel::Udp(UdpSocketChannel::new(udp_socket));
+        let udp_channel = StunChannel::UdpAny(UdpSocketChannel::new(udp_socket));
         let udp_stun_agent = StunAgent::new(udp_channel);
         let mut receive_stream = udp_stun_agent.receive_stream();
 
@@ -90,7 +90,7 @@ fn main() -> io::Result<()> {
         let tcp_listener = TcpListener::bind("127.0.0.1:3478").await?;
         let mut incoming = tcp_listener.incoming();
         while let Some(Ok(stream)) = incoming.next().await {
-            let tcp_channel = SocketChannel::Tcp(TcpChannel::new(stream));
+            let tcp_channel = StunChannel::Tcp(StunOnlyTcpChannel::new(stream));
             let tcp_stun_agent = StunAgent::new(tcp_channel);
             let mut receive_stream = tcp_stun_agent.receive_stream();
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,298 @@
+// Copyright (C) 2020 Matthew Waters <matthew@centricular.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+use futures_timer::Delay;
+use once_cell::sync::Lazy;
+
+#[async_trait]
+pub(crate) trait Clock: std::fmt::Debug + std::marker::Send + std::marker::Sync {
+    async fn delay(
+        &self,
+        duration: Duration,
+    ) -> Box<dyn ClockEntry + std::marker::Send + std::marker::Sync>;
+    fn now(&self) -> Instant;
+}
+
+#[async_trait]
+pub(crate) trait ClockEntry:
+    std::fmt::Debug + std::marker::Send + std::marker::Sync
+{
+    // FIXME: impl Future instead
+    async fn wait(&self);
+}
+
+#[derive(Debug)]
+struct SystemClock {}
+
+impl Default for SystemClock {
+    fn default() -> Self {
+        SystemClock {}
+    }
+}
+
+#[async_trait]
+impl Clock for SystemClock {
+    async fn delay(
+        &self,
+        duration: Duration,
+    ) -> Box<dyn ClockEntry + std::marker::Send + std::marker::Sync> {
+        Box::new(SystemClockEntry {
+            delay: Arc::new(Mutex::new(Some(Delay::new(duration)))), //delay: Delay::new(duration)
+        })
+    }
+
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+#[derive(Debug)]
+struct SystemClockEntry {
+    delay: Arc<Mutex<Option<Delay>>>,
+}
+
+#[async_trait]
+impl ClockEntry for SystemClockEntry {
+    async fn wait(&self) {
+        // XXX: is multiple waiters a thing?
+        let delay = {
+            let mut delay_guard = self.delay.lock().unwrap();
+            delay_guard.take()
+        };
+        if let Some(delay) = delay {
+            delay.await
+        }
+    }
+}
+
+pub(crate) enum ClockType {
+    System,
+    // XXX: currently unused and TestClock is created directly
+    //#[cfg(test)]
+    // Test,
+}
+
+impl Default for ClockType {
+    fn default() -> Self {
+        ClockType::System
+    }
+}
+
+static SYSTEM_CLOCK_INSTANCE: Lazy<Arc<dyn Clock>> = Lazy::new(|| Arc::new(SystemClock::default()));
+
+pub(crate) fn get_clock(clock_type: ClockType) -> Arc<dyn Clock> {
+    match clock_type {
+        ClockType::System => SYSTEM_CLOCK_INSTANCE.clone(),
+        //#[cfg(test)]
+        //ClockType::Test => Arc::new(tests::TestClock::default()),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use async_std::task;
+
+    use crate::utils::ChannelBroadcast;
+
+    use super::*;
+    use std::sync::{Arc, Mutex, Weak};
+
+    #[derive(Debug)]
+    pub(crate) struct TestClock {
+        inner: Arc<Mutex<TestClockInner>>,
+        new_instant_recv: async_channel::Receiver<Instant>,
+        new_instant_send: async_channel::Sender<Instant>,
+    }
+
+    impl TestClock {
+        #[tracing::instrument(level = "debug", skip(self))]
+        pub(crate) async fn advance(&self) {
+            while let Ok(instant) = self.new_instant_recv.recv().await {
+                trace!("received instant {:?}", instant);
+                let to_broadcast = {
+                    let mut inner = self.inner.lock().unwrap();
+                    if instant > inner.now {
+                        inner.now = instant;
+                        trace!("now is {:?}", instant);
+                        Some((inner.broadcast.clone(), instant))
+                    } else {
+                        None
+                    }
+                };
+                if let Some((broadcast, instant)) = to_broadcast {
+                    broadcast.broadcast(instant).await;
+                    break;
+                }
+            }
+        }
+
+        pub(crate) async fn set_time(&self, instant: Instant) {
+            let (broadcast, instant) = {
+                let mut inner = self.inner.lock().unwrap();
+                if instant > inner.now {
+                    trace!("now is {:?}", instant);
+                    inner.now = instant;
+                }
+                (inner.broadcast.clone(), inner.now)
+            };
+            broadcast.broadcast(instant).await;
+        }
+    }
+
+    impl Default for TestClock {
+        fn default() -> Self {
+            let (send, recv) = async_channel::bounded(512);
+            TestClock {
+                inner: Arc::new(Mutex::new(TestClockInner::default())),
+                new_instant_send: send,
+                new_instant_recv: recv,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestClockInner {
+        start: Instant,
+        now: Instant,
+        broadcast: Arc<ChannelBroadcast<Instant>>,
+    }
+
+    impl Default for TestClockInner {
+        fn default() -> Self {
+            let now = Instant::now();
+            TestClockInner {
+                start: now,
+                now,
+                broadcast: Arc::new(ChannelBroadcast::default()),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestClockEntry {
+        inner: Weak<Mutex<TestClockInner>>,
+        wait_until: Instant,
+    }
+
+    impl TestClockEntry {
+        fn new(inner: &Arc<Mutex<TestClockInner>>, wait_until: Instant) -> Self {
+            TestClockEntry {
+                inner: Arc::downgrade(inner),
+                wait_until,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ClockEntry for TestClockEntry {
+        #[tracing::instrument(skip(self))]
+        async fn wait(&self) {
+            let inner = match self.inner.upgrade() {
+                Some(inner) => inner,
+                None => return,
+            };
+            let receiver = {
+                let inner = inner.lock().unwrap();
+                if inner.now >= self.wait_until {
+                    trace!(
+                        "now {:?} has already passed wait time {:?}",
+                        inner.now,
+                        self.wait_until
+                    );
+                    return;
+                }
+                trace!(
+                    "now {:?} has not reached wait time {:?}",
+                    inner.now,
+                    self.wait_until
+                );
+                inner.broadcast.channel()
+            };
+            while let Ok(val) = receiver.recv().await {
+                if val >= self.wait_until {
+                    trace!(
+                        "clock time {:?} has passed wait time {:?}",
+                        val,
+                        self.wait_until
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Clock for TestClock {
+        async fn delay(
+            &self,
+            duration: Duration,
+        ) -> Box<dyn ClockEntry + std::marker::Send + std::marker::Sync> {
+            let wait_until = {
+                let inner = self.inner.lock().unwrap();
+                let wait_until = inner.now + duration;
+                trace!("new delay until {:?}", wait_until);
+                wait_until
+            };
+            self.new_instant_send.send(wait_until).await.unwrap();
+            Box::new(TestClockEntry::new(&self.inner, wait_until))
+        }
+
+        fn now(&self) -> Instant {
+            let inner = self.inner.lock().unwrap();
+            let now = inner.now;
+            trace!("now {:?}", now);
+            now
+        }
+    }
+
+    #[test]
+    fn system_clock_wait() {
+        task::spawn(async move {
+            let clock = get_clock(ClockType::System);
+            let start = clock.now();
+            let dur = Duration::from_secs(1);
+            let entry = clock.delay(dur).await;
+            entry.wait().await;
+            assert!(clock.now() >= start + dur);
+        });
+    }
+
+    #[test]
+    fn test_clock_advance() {
+        task::spawn(async move {
+            let clock = TestClock::default();
+            let start = clock.now();
+            let dur = Duration::from_millis(100);
+            let entry = clock.delay(dur).await;
+            let f = task::spawn(async move {
+                entry.wait().await;
+            });
+            clock.advance().await;
+            assert!(clock.now() >= start + dur);
+            f.await;
+        });
+    }
+
+    #[test]
+    fn test_clock_set_time() {
+        task::spawn(async move {
+            let clock = TestClock::default();
+            let start = clock.now();
+            let dur = Duration::from_millis(100);
+            let entry = clock.delay(dur).await;
+            clock.set_time(start + dur).await;
+            entry.wait().await;
+            assert!(clock.now() >= start + dur);
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate derivative;
 
 pub mod agent;
 pub mod candidate;
+mod clock;
 pub mod component;
 mod conncheck;
 pub mod gathering;

--- a/src/stun/agent.rs
+++ b/src/stun/agent.rs
@@ -358,7 +358,7 @@ impl StunAgentState {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::socket::{StunOnlyTcpChannel, UdpConnectionChannel};
+    use crate::socket::{TcpChannel, UdpConnectionChannel};
     use crate::stun::attribute::{Software, SOFTWARE};
     use async_std::net::{TcpListener, TcpStream};
     use async_std::task;
@@ -539,14 +539,14 @@ pub(crate) mod tests {
             let mut incoming = listener.incoming();
             let tcp2 = incoming.next();
             let tcp1 = task::spawn(async move { TcpStream::connect(local_addr).await });
-            let _tcp2 = tcp2.await.unwrap().unwrap();
-            let _tcp1 = tcp1.await.unwrap();
+            let tcp2 = tcp2.await.unwrap().unwrap();
+            let tcp1 = tcp1.await.unwrap();
 
             // TODO: need the correct rfc framing to send data
-            //let socket_channel1 = StunChannel::Tcp(TcpChannel::new(tcp1));
-            //let socket_channel2 = StunChannel::Tcp(TcpChannel::new(tcp2));
+            let socket_channel1 = StunChannel::Tcp(TcpChannel::new(tcp1));
+            let socket_channel2 = StunChannel::Tcp(TcpChannel::new(tcp2));
 
-            //send_and_receive(socket_channel1, socket_channel2).await;
+            send_and_receive(socket_channel1, socket_channel2).await;
         });
     }
 
@@ -563,7 +563,7 @@ pub(crate) mod tests {
             let addr2 = tcp1.local_addr().unwrap();
             let tcp2 = incoming.next().await.unwrap().unwrap();
             info!("connected");
-            let agent = StunAgent::new(StunChannel::Tcp(StunOnlyTcpChannel::new(tcp2)));
+            let agent = StunAgent::new(StunChannel::Tcp(TcpChannel::new(tcp2)));
 
             let software_str = "ab";
             let mut msg = Message::new_request(48);

--- a/src/stun/mod.rs
+++ b/src/stun/mod.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 pub mod agent;
 pub mod attribute;
 pub mod message;
-pub mod pacer;
+//mod pacer;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransportType {

--- a/src/stun/mod.rs
+++ b/src/stun/mod.rs
@@ -6,6 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::error::Error;
+use std::str::FromStr;
+
 pub mod agent;
 pub mod attribute;
 pub mod message;
@@ -16,5 +19,32 @@ pub enum TransportType {
     Udp,
     Tcp,
     #[cfg(test)]
-    AsyncChannel
+    AsyncChannel,
+}
+
+#[derive(Debug)]
+pub enum ParseTransportTypeError {
+    UnknownTransport,
+}
+
+impl Error for ParseTransportTypeError {}
+
+impl std::fmt::Display for ParseTransportTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for TransportType {
+    type Err = ParseTransportTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "UDP" => Ok(TransportType::Udp),
+            "TCP" => Ok(TransportType::Tcp),
+            #[cfg(test)]
+            "AsyncChannel" => Ok(TransportType::AsyncChannel),
+            _ => Err(ParseTransportTypeError::UnknownTransport),
+        }
+    }
 }

--- a/src/stun/mod.rs
+++ b/src/stun/mod.rs
@@ -15,4 +15,6 @@ pub mod pacer;
 pub enum TransportType {
     Udp,
     Tcp,
+    #[cfg(test)]
+    AsyncChannel
 }

--- a/src/stun/pacer.rs
+++ b/src/stun/pacer.rs
@@ -6,12 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
-
-use futures_timer::Delay;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::utils::ChannelBroadcast;
+
+use crate::clock::{Clock, get_clock, ClockType};
 
 pub const STUN_REQUEST_PACE_TIME: Duration = Duration::from_millis(2000);
 
@@ -24,6 +24,7 @@ where
     recv_s: async_channel::Sender<T>,
     sender_broadcast: ChannelBroadcast<T>,
     state: Mutex<PaceState>,
+    clock: Arc<dyn Clock>,
 }
 
 #[derive(Debug, Clone)]
@@ -32,56 +33,91 @@ struct PaceState {
     last_message_ts: Option<std::time::Instant>,
 }
 
-impl<T> ChannelPacer<T>
-where
-    T: std::fmt::Debug + Clone,
-{
-    pub fn new(pacing: Duration) -> Self {
-        let (send, recv) = async_channel::bounded(16);
+#[derive(Debug)]
+pub(crate) struct PacerBuilder {
+    pacing: Duration,
+    clock: Option<Arc<dyn Clock>>,
+}
+
+impl PacerBuilder {
+    fn new(pacing: Duration) -> Self {
         Self {
+            pacing,
+            clock: None,
+        }
+    }
+
+    pub(crate) fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
+    pub(crate) fn build<T>(self) -> ChannelPacer<T>
+    where
+        T: std::fmt::Debug + Clone
+    {
+        let (send, recv) = async_channel::bounded(16);
+        let clock = self.clock.unwrap_or_else(|| get_clock(ClockType::default()));
+        ChannelPacer {
             recv_r: recv,
             recv_s: send,
             sender_broadcast: ChannelBroadcast::default(),
             state: Mutex::new(PaceState {
-                pacing,
+                pacing: self.pacing,
                 last_message_ts: None,
             }),
+            clock,
         }
     }
+}
 
-    pub async fn send_loop(&self) {
+impl<T> ChannelPacer<T>
+where
+    T: std::fmt::Debug + Clone,
+{
+    pub(crate) fn new(pacing: Duration) -> Self {
+        Self::builder(pacing).build()
+    }
+
+    pub(crate) fn builder(pacing: Duration) -> PacerBuilder {
+        PacerBuilder::new(pacing)
+    }
+
+    pub(crate) async fn send_loop(&self) {
         while let Ok(item) = self.recv_r.recv().await {
             let delay = {
                 let state = self.state.lock().unwrap();
 
                 // delay the message if necessary
                 if let Some(last_ts) = state.last_message_ts {
+                    let elapsed = self.clock.now() - last_ts;
                     trace!(
                         "elapsed, {:?} pacing, {:?}",
-                        last_ts.elapsed(),
+                        elapsed,
                         state.pacing
                     );
-                    state.pacing.checked_sub(last_ts.elapsed())
+                    state.pacing.checked_sub(elapsed)
                 } else {
                     None
                 }
             };
             if let Some(delay) = delay {
                 trace!("delaying for {:?}", delay);
-                Delay::new(delay).await;
+                let delay = self.clock.delay(delay).await;
+                delay.wait().await;
             }
             self.sender_broadcast.broadcast(item).await;
 
             let mut state = self.state.lock().unwrap();
-            state.last_message_ts = Some(Instant::now());
+            state.last_message_ts = Some(self.clock.now());
         }
     }
 
-    pub async fn send(&self, data: T) {
+    pub(crate) async fn send(&self, data: T) {
         self.recv_s.send(data).await.unwrap();
     }
 
-    pub fn recv_channel(&self) -> async_channel::Receiver<T> {
+    pub(crate) fn recv_channel(&self) -> async_channel::Receiver<T> {
         self.sender_broadcast.channel()
     }
 }
@@ -101,29 +137,27 @@ mod tests {
         init();
         task::block_on(async move {
             let pacing = Duration::from_millis(5000);
-            let pacer: Arc<ChannelPacer<u32>> = Arc::new(ChannelPacer::new(pacing));
+            let clock = get_clock(ClockType::Test);
+            let pacer: Arc<ChannelPacer<u32>> = Arc::new(ChannelPacer::<u32>::builder(pacing).clock(clock.clone()).build());
             let recv_channel = pacer.recv_channel();
             task::spawn({
                 let pacer = pacer.clone();
                 async move { pacer.send_loop().await }
             });
-            let result = Arc::new(Mutex::new(None));
             let f = task::spawn({
-                let result = result.clone();
                 async move {
                     let data = recv_channel.recv().await.unwrap();
                     info!("recv {:?}", data);
-                    let mut result = result.lock().unwrap();
-                    result.replace(Instant::now());
                 }
             });
 
-            let now = Instant::now();
+            let start_time = clock.now();
             info!("send 5");
             pacer.send(5).await;
             f.await;
-            info!("elapsed {:?}", now.elapsed());
-            assert!(now.elapsed() < pacing);
+            let end_time = clock.now();
+            info!("elapsed {:?}", end_time - start_time);
+            assert!(end_time - start_time < pacing);
         })
     }
 
@@ -132,33 +166,32 @@ mod tests {
         init();
         task::block_on(async move {
             let pacing = Duration::from_millis(2000);
-            let pacer: Arc<ChannelPacer<u32>> = Arc::new(ChannelPacer::new(pacing));
+            let clock = Arc::new(crate::clock::tests::TestClock::default());
+            let pacer: Arc<ChannelPacer<u32>> = Arc::new(ChannelPacer::<u32>::builder(pacing).clock(clock.clone()).build());
             let recv_channel = pacer.recv_channel();
             let wait1 = task::spawn({
                 let pacer = pacer.clone();
                 async move { pacer.send_loop().await }
             });
-            let result = Arc::new(Mutex::new(None));
-            let f = task::spawn({
-                let result = result.clone();
-                async move {
-                    let data = recv_channel.recv().await.unwrap();
-                    info!("recv {:?}", data);
-                    let data = recv_channel.recv().await.unwrap();
-                    info!("recv {:?}", data);
-                    let mut result = result.lock().unwrap();
-                    result.replace(Instant::now());
-                }
-            });
 
-            let now = Instant::now();
+            let start_time = clock.now();
             info!("send 5");
             pacer.send(5).await;
             info!("send 6");
             pacer.send(6).await;
-            f.await;
-            info!("elapsed {:?}", now.elapsed());
-            assert!(now.elapsed() >= pacing);
+
+            let data = recv_channel.recv().await.unwrap();
+            info!("recv {:?}", data);
+
+            clock.advance().await;
+            info!("clock advanced");
+
+            let data = recv_channel.recv().await.unwrap();
+            info!("recv {:?}", data);
+
+            let end_time = clock.now();
+            info!("elapsed {:?}", end_time - start_time);
+            assert!(end_time - start_time >= pacing);
             wait1.cancel().await;
         })
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,6 +38,11 @@ impl<T> std::ops::Deref for DebugWrapper<T> {
         &self.1
     }
 }
+impl<T> std::ops::DerefMut for DebugWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.1
+    }
+}
 impl<T> DebugWrapper<T> {
     pub(crate) fn wrap(obj: T, name: &'static str) -> Self {
         Self(name, obj)
@@ -98,8 +103,10 @@ where
         let mut removed = vec![];
         for (i, channel) in channels.iter().enumerate() {
             if (channel.filter)(&data) {
+                trace!("passed filter");
                 // XXX: maybe a parallel send?
-                if channel.sender.send(data.clone()).await.is_err() {
+                if let Err(e) = channel.sender.send(data.clone()).await {
+                    trace!("sender has errored with {:?}", e);
                     removed.push(i);
                 }
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,7 +18,7 @@ use async_std::net::{TcpListener, UdpSocket};
 use futures::StreamExt;
 
 use librice::agent::*;
-use librice::socket::{SocketChannel, TcpChannel, UdpSocketChannel};
+use librice::socket::*;
 use librice::stun::agent::*;
 use librice::stun::attribute::*;
 use librice::stun::message::*;
@@ -92,7 +92,7 @@ pub async fn handle_stun(stun_agent: StunAgent) -> std::io::Result<()> {
 #[allow(dead_code)]
 pub async fn stund_udp(socket: UdpSocket) -> std::io::Result<()> {
     let addr = socket.local_addr()?;
-    let channel = SocketChannel::Udp(UdpSocketChannel::new(socket));
+    let channel = StunChannel::UdpAny(UdpSocketChannel::new(socket));
     let stun_agent = StunAgent::new(channel);
 
     handle_stun(stun_agent).await.unwrap();
@@ -106,7 +106,7 @@ pub async fn stund_tcp(listener: TcpListener) -> std::io::Result<()> {
     let addr = listener.local_addr()?;
     while let Some(Ok(stream)) = incoming.next().await {
         async_std::task::spawn(async move {
-            let channel = SocketChannel::Tcp(TcpChannel::new(stream));
+            let channel = StunChannel::Tcp(StunOnlyTcpChannel::new(stream));
             let stun_agent = StunAgent::new(channel);
             handle_stun(stun_agent).await.unwrap();
         });

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -106,7 +106,7 @@ pub async fn stund_tcp(listener: TcpListener) -> std::io::Result<()> {
     let addr = listener.local_addr()?;
     while let Some(Ok(stream)) = incoming.next().await {
         async_std::task::spawn(async move {
-            let channel = StunChannel::Tcp(StunOnlyTcpChannel::new(stream));
+            let channel = StunChannel::Tcp(TcpChannel::new(stream));
             let stun_agent = StunAgent::new(channel);
             handle_stun(stun_agent).await.unwrap();
         });


### PR DESCRIPTION
Some other misc improvements
- deps update
- stunclient/stund better error reporting
- test clock implementatio so we don't always have to wait for the 30s+ timeout for stun to fail in tests.
- initial SDP candidate parsing