### PR TITLE
conncheck: readd the original check in slightly more cases

### DIFF
--- a/librice-proto/src/conncheck.rs
+++ b/librice-proto/src/conncheck.rs
@@ -1959,6 +1959,7 @@ impl ConnCheckListSet {
                 CandidatePairState::Succeeded => {
                     if peer_nominating && !check.nominate() {
                         debug!("existing pair succeeded -> nominate");
+                        checklist.add_check(check.clone());
                         check = ConnCheck::clone_with_pair_nominate(
                             &check,
                             checklist.checklist_id,
@@ -1989,6 +1990,7 @@ impl ConnCheckListSet {
                     check.cancel_retransmissions();
                     // TODO: ignore response timeouts
 
+                    checklist.add_check(check.clone());
                     check = ConnCheck::clone_with_pair_nominate(
                         &check,
                         checklist.checklist_id,


### PR DESCRIPTION
So that we don't get into a loop of removing the current conncheck and readding a new copy  with the peer.