### PR TITLE
conncheck: fix duplicate triggered check handling

### DIFF
--- a/librice-proto/src/capi.rs
+++ b/librice-proto/src/capi.rs
@@ -1604,13 +1604,13 @@ mod tests {
             let remote_credentials =
                 credentials_to_c(Credentials::new("ruser".to_string(), "rpass".to_string()));
 
-            rice_agent_add_stun_server(agent, transport, stun_addr);
+            rice_agent_add_stun_server(agent, transport.into(), stun_addr);
             rice_address_free(mut_override(stun_addr));
             rice_stream_set_local_credentials(stream, local_credentials);
             rice_credentials_free(local_credentials);
             rice_stream_set_remote_credentials(stream, remote_credentials);
             rice_credentials_free(remote_credentials);
-            rice_component_gather_candidates(component, 1, &mut_override(addr), &transport);
+            rice_component_gather_candidates(component, 1, &mut_override(addr), &transport.into());
             rice_address_free(mut_override(addr));
 
             let ret = rice_stream_poll_gather(stream, 0);
@@ -1637,7 +1637,8 @@ mod tests {
 
             let tcp_from_addr = "192.168.200.4:3000".parse().unwrap();
             let tcp_from_addr = RiceAddress(tcp_from_addr).to_c();
-            let stun_agent = rice_stun_agent_new(TransportType::Tcp, tcp_from_addr, need_agent.to);
+            let stun_agent =
+                rice_stun_agent_new(TransportType::Tcp.into(), tcp_from_addr, need_agent.to);
             let _tcp_from_addr = RiceAddress::from_c(tcp_from_addr);
             rice_stream_handle_gather_tcp_connect(
                 stream,

--- a/librice-proto/src/conncheck.rs
+++ b/librice-proto/src/conncheck.rs
@@ -1126,7 +1126,7 @@ impl ConnCheckList {
                     check.set_state(CandidatePairState::Waiting);
                 }
             }
-            self.add_check_if_not_duplicate(check)
+            self.add_check_if_not_duplicate(check);
         }
     }
 
@@ -1160,7 +1160,7 @@ impl ConnCheckList {
             .find(|&check| Self::check_is_equal(check, pair, nominate))
     }
 
-    fn add_check_if_not_duplicate(&mut self, check: ConnCheck) {
+    fn add_check_if_not_duplicate(&mut self, check: ConnCheck) -> bool {
         if let Some(idx) = self
             .pairs
             .iter()
@@ -1176,11 +1176,12 @@ impl ConnCheckList {
                 debug!("removing existing check {:?}", existing);
             } else {
                 debug!("not adding duplicate check");
-                return;
+                return false;
             }
         }
 
         self.add_check(check);
+        true
     }
 
     fn add_check(&mut self, check: ConnCheck) {
@@ -2181,8 +2182,10 @@ impl ConnCheckListSet {
             // TODO: need to construct correct pair priorities and foundations,
             // just use whatever the conncheck produced for now
             ok_check.set_state(CandidatePairState::Succeeded);
-            checklist.add_valid(ok_check.conncheck_id, &ok_check.pair);
-            checklist.add_check_if_not_duplicate(ok_check);
+            let ok_id = ok_check.conncheck_id;
+            if checklist.add_check_if_not_duplicate(ok_check) {
+                checklist.add_valid(ok_id, &ok_pair);
+            }
             checklist.add_valid(conncheck_id, &pair);
 
             if nominate {


### PR DESCRIPTION
A check being triggered twice may result in the second trigger producing a large wait that may never be completed.  That is not ideal and we instead assert that this must not happen with a panic().

Then fixing the panic involves not triggering a check if it is already has an associated STUN request.