### PR TITLE
dev: remove use of EnvFilter entirely

### DIFF
--- a/librice-proto/Cargo.toml
+++ b/librice-proto/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 workspace = ".."
 
 [features]
-capi = ["libc", "socket2", "tracing-subscriber/env-filter", "get_if_addrs"]
+capi = ["libc", "tracing-subscriber", "get_if_addrs"]
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
@@ -28,7 +28,7 @@ stun-proto.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber.workspace = true
 
 [package.metadata.capi]
 min_version = "0.9.21"

--- a/librice-proto/src/agent.rs
+++ b/librice-proto/src/agent.rs
@@ -429,13 +429,9 @@ pub struct AgentComponentStateChange {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn controlling() {
-        init();
+        let _log = crate::tests::test_init_log();
         let agent = Agent::builder().controlling(true).build();
         assert!(agent.controlling());
         let agent = Agent::builder().controlling(false).build();

--- a/librice-proto/src/candidate.rs
+++ b/librice-proto/src/candidate.rs
@@ -711,13 +711,9 @@ impl CandidatePair {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn candidate_pair_redundant_with_itself() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let remote_addr: SocketAddr = "127.0.0.1:9100".parse().unwrap();
         let pair = CandidatePair::new(
@@ -744,7 +740,7 @@ mod tests {
 
     #[test]
     fn candidate_priority() {
-        init();
+        let _log = crate::tests::test_init_log();
         let ctypes = [
             CandidateType::Host,
             CandidateType::ServerReflexive,
@@ -797,7 +793,7 @@ mod tests {
 
         #[test]
         fn udp_candidate() {
-            init();
+            let _log = crate::tests::test_init_log();
             let s = "a=candidate:0 1 UDP 1234 127.0.0.1 2345 typ host";
             let cand = Candidate::from_str(s).unwrap();
             debug!("cand {:?}", cand);
@@ -811,7 +807,7 @@ mod tests {
         }
         #[test]
         fn candidate_not_candidate() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a"),
                 Err(ParseCandidateError::NotCandidate)
@@ -819,7 +815,7 @@ mod tests {
         }
         #[test]
         fn candidate_missing_space() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 1UDP 1234 127.0.0.1 2345 typ host"),
                 Err(ParseCandidateError::Malformed)
@@ -827,7 +823,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_foundation() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:= 1 UDP 1234 127.0.0.1 2345 typ host"),
                 Err(ParseCandidateError::BadFoundation)
@@ -835,7 +831,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_component_id() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 component-id UDP 1234 127.0.0.1 2345 type host"),
                 Err(ParseCandidateError::BadComponentId)
@@ -843,7 +839,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_transport_type() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 1 transport 1234 127.0.0.1 2345 typ host"),
                 Err(ParseCandidateError::BadTransportType)
@@ -851,7 +847,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_priority() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 1 UDP priority 127.0.0.1 2345 typ host"),
                 Err(ParseCandidateError::BadPriority)
@@ -859,7 +855,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_address() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 1 UDP 1234 address 2345 typ host"),
                 Err(ParseCandidateError::BadAddress)
@@ -867,7 +863,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_port() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 1 UDP 1234 127.0.0.1 port type host"),
                 Err(ParseCandidateError::BadAddress)
@@ -875,7 +871,7 @@ mod tests {
         }
         #[test]
         fn candidate_bad_candidate_type() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:0 1 UDP 1234 127.0.0.1 2345 candidate-type"),
                 Err(ParseCandidateError::BadCandidateType)
@@ -883,7 +879,7 @@ mod tests {
         }
         #[test]
         fn host_candidate_sdp_string() {
-            init();
+            let _log = crate::tests::test_init_log();
             let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
             let cand_sdp_str = "a=candidate:foundation 1 UDP 1234 127.0.0.1 9000 typ host";
             let cand = Candidate::builder(
@@ -901,7 +897,7 @@ mod tests {
         }
         #[test]
         fn tcp_candidate() {
-            init();
+            let _log = crate::tests::test_init_log();
             let addr: SocketAddr = "127.0.0.1:2345".parse().unwrap();
             let cand = Candidate::builder(
                 1,
@@ -921,7 +917,7 @@ mod tests {
         }
         #[test]
         fn tcp_candidate_without_tcp_type() {
-            init();
+            let _log = crate::tests::test_init_log();
             assert!(matches!(
                 Candidate::from_str("a=candidate:foundation 1 TCP 1234 127.0.0.1 2345 typ host"),
                 Err(ParseCandidateError::BadTransportType)
@@ -929,7 +925,7 @@ mod tests {
         }
         #[test]
         fn related_address() {
-            init();
+            let _log = crate::tests::test_init_log();
             let addr: SocketAddr = "127.0.0.1:2345".parse().unwrap();
             let related_addr: SocketAddr = "192.168.0.1:9876".parse().unwrap();
             let cand = Candidate::builder(
@@ -950,7 +946,7 @@ mod tests {
         }
         #[test]
         fn extension_attributes() {
-            init();
+            let _log = crate::tests::test_init_log();
             let addr: SocketAddr = "127.0.0.1:2345".parse().unwrap();
             let cand = Candidate::builder(
                 1,

--- a/librice-proto/src/component.rs
+++ b/librice-proto/src/component.rs
@@ -187,13 +187,9 @@ mod tests {
     use super::*;
     use crate::agent::Agent;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn initial_state_new() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut agent = Agent::builder().build();
         let sid = agent.add_stream();
         let mut s = agent.mut_stream(sid).unwrap();

--- a/librice-proto/src/conncheck.rs
+++ b/librice-proto/src/conncheck.rs
@@ -2740,13 +2740,9 @@ mod tests {
     use super::*;
     use crate::candidate::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn nominate_eq_bool() {
-        init();
+        let _log = crate::tests::test_init_log();
         assert!(Nominate::DontCare.eq(&true));
         assert!(Nominate::DontCare.eq(&false));
         assert!(Nominate::True.eq(&true));
@@ -2757,7 +2753,7 @@ mod tests {
 
     #[test]
     fn nominate_eq_nominate() {
-        init();
+        let _log = crate::tests::test_init_log();
         assert!(Nominate::DontCare.eq(&Nominate::DontCare));
         assert!(Nominate::DontCare.eq(&Nominate::True));
         assert!(Nominate::DontCare.eq(&Nominate::False));
@@ -2923,7 +2919,7 @@ mod tests {
 
     #[test]
     fn get_candidates() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut set = ConnCheckListSet::builder(0, true).build();
         let list = set.new_list();
         let list = set.mut_list(list).unwrap();
@@ -3055,7 +3051,7 @@ mod tests {
 
     #[test]
     fn conncheck_list_transmit() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().build();
         let now = Instant::now();
 
@@ -3088,7 +3084,7 @@ mod tests {
 
     #[test]
     fn checklist_generate_checks() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut set = ConnCheckListSet::builder(0, true).build();
         let list = set.new_list();
         let list = set.mut_list(list).unwrap();
@@ -3139,7 +3135,7 @@ mod tests {
 
     #[test]
     fn checklists_initial_thaw() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut thawn = vec![];
         let mut set = ConnCheckListSet::builder(0, true).build();
         let list1_id = set.new_list();
@@ -3405,7 +3401,7 @@ mod tests {
 
     #[test]
     fn very_fine_control1() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().build();
         let mut now = Instant::now();
         assert_eq!(state.local.component_id, 1);
@@ -3489,7 +3485,7 @@ mod tests {
 
     #[test]
     fn role_conflict_response() {
-        init();
+        let _log = crate::tests::test_init_log();
         // start off in the controlled mode, otherwise, the test needs to do the nomination
         // check
         let mut state = FineControl::builder().controlling(false).build();
@@ -3596,7 +3592,7 @@ mod tests {
 
     #[test]
     fn bad_username_conncheck() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().build();
         let now = Instant::now();
         let local_list = state
@@ -3644,7 +3640,7 @@ mod tests {
 
     #[test]
     fn conncheck_tcp_active() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder();
         state.local_peer_builder = state
             .local_peer_builder
@@ -3769,7 +3765,7 @@ mod tests {
 
     #[test]
     fn conncheck_tcp_passive() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder();
         state.local_peer_builder = state
             .local_peer_builder
@@ -3933,7 +3929,7 @@ mod tests {
 
     #[test]
     fn conncheck_incoming_prflx() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().build();
         let now = Instant::now();
 
@@ -4074,7 +4070,7 @@ mod tests {
 
     #[test]
     fn conncheck_response_prflx() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().build();
         let now = Instant::now();
 
@@ -4167,7 +4163,7 @@ mod tests {
 
     #[test]
     fn conncheck_trickle_ice() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().trickle_ice(true).build();
         let mut now = Instant::now();
         assert_eq!(state.local.component_id, 1);
@@ -4265,7 +4261,7 @@ mod tests {
 
     #[test]
     fn conncheck_trickle_ice_no_remote_candidates_fail() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().trickle_ice(true).build();
         let local_candidate = state.local.peer.candidate.clone();
 
@@ -4293,6 +4289,7 @@ mod tests {
 
     #[test]
     fn conncheck_set_trickle_no_checks() {
+        let _log = crate::tests::test_init_log();
         // ensure that a set of empty lists does not busyloop
         let mut set = ConnCheckListSet::builder(0, false)
             .trickle_ice(true)
@@ -4308,7 +4305,7 @@ mod tests {
 
     #[test]
     fn conncheck_incoming_request_while_local_in_progress() {
-        init();
+        let _log = crate::tests::test_init_log();
         let mut state = FineControl::builder().build();
 
         // generate existing checks

--- a/librice-proto/src/gathering.rs
+++ b/librice-proto/src/gathering.rs
@@ -595,13 +595,9 @@ mod tests {
 
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn host_udp() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "192.168.1.1:1000".parse().unwrap();
         let mut gather = StunGatherer::new(1, vec![(TransportType::Udp, local_addr)], vec![]);
         let now = Instant::now();
@@ -624,7 +620,7 @@ mod tests {
 
     #[test]
     fn host_tcp() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "192.168.1.1:1000".parse().unwrap();
         let mut gather = StunGatherer::new(1, vec![(TransportType::Tcp, local_addr)], vec![]);
         let now = Instant::now();
@@ -661,7 +657,7 @@ mod tests {
 
     #[test]
     fn stun_udp() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "192.168.1.1:1000".parse().unwrap();
         let stun_addr = "192.168.1.2:2000".parse().unwrap();
         let public_ip = "192.168.1.3:3000".parse().unwrap();
@@ -720,7 +716,7 @@ mod tests {
 
     #[test]
     fn stun_tcp() {
-        init();
+        let _log = crate::tests::test_init_log();
         let local_addr = "192.168.1.1:1000".parse().unwrap();
         let stun_addr = "192.168.1.2:2000".parse().unwrap();
         let public_ip = "192.168.1.3:3000".parse().unwrap();

--- a/librice-proto/src/lib.rs
+++ b/librice-proto/src/lib.rs
@@ -21,16 +21,29 @@ pub mod capi;
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Once;
-    use tracing_subscriber::EnvFilter;
+    use tracing::subscriber::DefaultGuard;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Layer;
 
-    static TRACING: Once = Once::new();
+    use super::*;
 
-    pub fn test_init_log() {
-        TRACING.call_once(|| {
-            if let Ok(filter) = EnvFilter::try_from_default_env() {
-                tracing_subscriber::fmt().with_env_filter(filter).init();
-            }
-        });
+    pub fn test_init_log() -> DefaultGuard {
+        let level_filter = std::env::var("RICE_LOG")
+            .or(std::env::var("RUST_LOG"))
+            .ok()
+            .and_then(|var| var.parse::<tracing_subscriber::filter::Targets>().ok())
+            .unwrap_or(
+                tracing_subscriber::filter::Targets::new().with_default(tracing::Level::TRACE),
+            );
+        let registry = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_file(true)
+                .with_line_number(true)
+                .with_level(true)
+                .with_target(false)
+                .with_test_writer()
+                .with_filter(level_filter),
+        );
+        tracing::subscriber::set_default(registry)
     }
 }

--- a/librice-proto/src/stream.rs
+++ b/librice-proto/src/stream.rs
@@ -646,13 +646,9 @@ impl StreamState {
 mod tests {
     use super::*;
 
-    fn init() {
-        crate::tests::test_init_log();
-    }
-
     #[test]
     fn getters_setters() {
-        init();
+        let _log = crate::tests::test_init_log();
         let lcreds = Credentials::new("luser".into(), "lpass".into());
         let rcreds = Credentials::new("ruser".into(), "rpass".into());
 

--- a/librice/Cargo.toml
+++ b/librice/Cargo.toml
@@ -25,6 +25,3 @@ tracing.workspace = true
 tracing-futures = { version = "0.2", default-features = false, features = ["std", "std-future", "futures-03"] }
 tracing-subscriber.workspace = true
 stun-proto.workspace = true
-
-[dev-dependencies]
-tracing-subscriber = { workspace = true, features = ["env-filter"]}

--- a/librice/src/lib.rs
+++ b/librice/src/lib.rs
@@ -23,15 +23,30 @@ pub use stun_proto::types as stun;
 #[cfg(test)]
 pub(crate) mod tests {
     use std::sync::Once;
-    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Layer;
 
     static TRACING: Once = Once::new();
 
     pub fn test_init_log() {
         TRACING.call_once(|| {
-            if let Ok(filter) = EnvFilter::try_from_default_env() {
-                tracing_subscriber::fmt().with_env_filter(filter).init();
-            }
+            let level_filter = std::env::var("RICE_LOG")
+                .or(std::env::var("RUST_LOG"))
+                .ok()
+                .and_then(|var| var.parse::<tracing_subscriber::filter::Targets>().ok())
+                .unwrap_or(
+                    tracing_subscriber::filter::Targets::new().with_default(tracing::Level::ERROR),
+                );
+            let registry = tracing_subscriber::registry().with(
+                tracing_subscriber::fmt::layer()
+                    .with_file(true)
+                    .with_line_number(true)
+                    .with_level(true)
+                    .with_target(false)
+                    .with_test_writer()
+                    .with_filter(level_filter),
+            );
+            tracing::subscriber::set_global_default(registry).unwrap();
         });
     }
 }


### PR DESCRIPTION
Removes roughly 1+MB from the resulting binary in unneeded regex code.