### PR TITLE
conncheck: reference stun agents by ID

### DIFF
--- a/librice-proto/src/agent.rs
+++ b/librice-proto/src/agent.rs
@@ -380,6 +380,19 @@ pub enum AgentPoll<'a> {
     ComponentStateChange(AgentComponentStateChange),
 }
 
+impl<'a> AgentPoll<'a> {
+    pub fn into_owned<'b>(self) -> AgentPoll<'b> {
+        match self {
+            Self::Closed => AgentPoll::Closed,
+            Self::WaitUntil(instant) => AgentPoll::WaitUntil(instant),
+            Self::Transmit(transmit) => AgentPoll::Transmit(transmit.into_owned()),
+            Self::TcpConnect(connect) => AgentPoll::TcpConnect(connect),
+            Self::SelectedPair(selected) => AgentPoll::SelectedPair(selected),
+            Self::ComponentStateChange(state) => AgentPoll::ComponentStateChange(state),
+        }
+    }
+}
+
 /// Transmit the data using the specified 5-tuple.
 #[derive(Debug)]
 pub struct AgentTransmit<'a> {

--- a/librice/src/agent.rs
+++ b/librice/src/agent.rs
@@ -275,7 +275,12 @@ impl futures::stream::Stream for AgentStream {
                     if let Some(component) = stream.component(pair.component_id) {
                         if let Some(socket) = stream.socket_for_pair(pair.selected.candidate_pair())
                         {
-                            component.set_selected_pair(SelectedPair::new(*pair.selected, socket));
+                            if let Err(e) = component.set_selected_pair(SelectedPair::new(
+                                pair.selected.candidate_pair().clone(),
+                                socket,
+                            )) {
+                                warn!("Failed setting the selected pair: {e:?}");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Removes the last `Arc<Mutex<>>` from librice-proto.