### PR TITLE
conncheck: small fixes and cleanups

### DIFF
--- a/librice-proto/src/conncheck.rs
+++ b/librice-proto/src/conncheck.rs
@@ -454,11 +454,21 @@ impl ConnCheckList {
 
     /// Set the local [`Credentials`] for this checklist
     pub fn set_local_credentials(&mut self, credentials: Credentials) {
+        for (_agent_id, agent) in self.agents.iter_mut() {
+            agent.set_local_credentials(MessageIntegrityCredentials::ShortTerm(
+                credentials.clone().into(),
+            ));
+        }
         self.local_credentials = credentials;
     }
 
     /// Set the remote [`Credentials`] for this checklist
     pub fn set_remote_credentials(&mut self, credentials: Credentials) {
+        for (_agent_id, agent) in self.agents.iter_mut() {
+            agent.set_remote_credentials(MessageIntegrityCredentials::ShortTerm(
+                credentials.clone().into(),
+            ));
+        }
         self.remote_credentials = credentials;
     }
 

--- a/librice-proto/src/conncheck.rs
+++ b/librice-proto/src/conncheck.rs
@@ -2146,15 +2146,15 @@ impl ConnCheckListSet {
 
         // if response success:
         // if mismatched address -> fail
-        /* FIXME
-        if from != request.peer_address() {
+        if from != conncheck.pair.remote.address {
             warn!(
                 "response came from different ip {:?} than candidate {:?}",
                 from,
-                stun_request.peer_address()
+                conncheck.pair.remote.address
             );
-            checklist.check_response_failure(conncheck.clone());
-        }*/
+            checklist.check_response_failure(conncheck_id);
+            return Ok(());
+        }
 
         // if response error -> fail TODO: might be a recoverable error!
         if response.has_class(MessageClass::Error) {


### PR DESCRIPTION
commit 01b6d228a996496b4386c7ebb0dc2de8ac0d83e3

    proto/capi: use stack allocated poll return structures
    
    There is no need to do an allocation or every single poll().

commit d19c1f143bcafd6bb58552dbb55ba7e64cde518a

    proto/conncheck: set the local/remote credentials on the internal agents
    
    Otherwise, when changing the credentials, the previous agent may use the
    wrong values.

commit 923e883d796f2f7afc3f03c2e2af453e1edc3562

    conncheck: reenable cancelling checks

commit 8f5454a8ecd80819a62d17d64029e852d0786db8

    conncheck: reenable checking remote incoming address

commit d7fcb9a7c8005208d828475b1f76a3f983bf6241

    proto/conncheck: remove explicit calls to generate_checks/initial_thaw
    
    generate_checks() is called automatically when adding local or remote
    candidates.
    
    inital_thaw() is covered entirely by the next_check() logic which will
    unfreeze the relevant frozen checks.