### PR TITLE
proto: use structured enum rather than tuple enums

### DIFF
--- a/librice-proto/src/agent.rs
+++ b/librice-proto/src/agent.rs
@@ -293,7 +293,11 @@ impl Agent {
                     }
                     break;
                 }
-                CheckListSetPollRet::Transmit(checklist_id, cid, transmit) => {
+                CheckListSetPollRet::Transmit {
+                    checklist_id,
+                    component_id: cid,
+                    transmit,
+                } => {
                     if let Some(stream) =
                         self.streams.iter().find(|s| s.checklist_id == checklist_id)
                     {
@@ -309,7 +313,12 @@ impl Agent {
                         );
                     }
                 }
-                CheckListSetPollRet::TcpConnect(checklist_id, cid, from, to) => {
+                CheckListSetPollRet::TcpConnect {
+                    checklist_id,
+                    component_id: cid,
+                    local_addr: from,
+                    remote_addr: to,
+                } => {
                     if let Some(stream) =
                         self.streams.iter().find(|s| s.checklist_id == checklist_id)
                     {
@@ -323,10 +332,10 @@ impl Agent {
                         warn!("did not find stream for tcp connect {from:?} -> {to:?}");
                     }
                 }
-                CheckListSetPollRet::Event(
+                CheckListSetPollRet::Event {
                     checklist_id,
-                    ConnCheckEvent::ComponentState(cid, state),
-                ) => {
+                    event: ConnCheckEvent::ComponentState(cid, state),
+                } => {
                     if let Some(stream) =
                         self.streams.iter().find(|s| s.checklist_id == checklist_id)
                     {
@@ -339,10 +348,10 @@ impl Agent {
                         }
                     }
                 }
-                CheckListSetPollRet::Event(
+                CheckListSetPollRet::Event {
                     checklist_id,
-                    ConnCheckEvent::SelectedPair(cid, selected),
-                ) => {
+                    event: ConnCheckEvent::SelectedPair(cid, selected),
+                } => {
                     if let Some(stream) =
                         self.streams.iter().find(|s| s.checklist_id == checklist_id)
                     {

--- a/librice-proto/src/capi.rs
+++ b/librice-proto/src/capi.rs
@@ -1015,12 +1015,21 @@ impl RiceGatherPoll {
             GatherPoll::WaitUntil(instant) => Self::WaitUntilMicros(
                 instant.saturating_duration_since(base_instant).as_micros() as u64,
             ),
-            GatherPoll::NeedAgent(component_id, transport, from, to) => Self::NeedAgent(
-                RiceGatherPollNeedAgent::from_rust(component_id, transport, from, to),
-            ),
-            GatherPoll::SendData(component_id, transmit) => {
-                Self::SendData(transmit_from_rust_gather(stream_id, component_id, transmit))
-            }
+            GatherPoll::NeedAgent {
+                component_id,
+                transport,
+                local_addr: from,
+                remote_addr: to,
+            } => Self::NeedAgent(RiceGatherPollNeedAgent::from_rust(
+                component_id,
+                transport,
+                from,
+                to,
+            )),
+            GatherPoll::SendData {
+                component_id,
+                transmit,
+            } => Self::SendData(transmit_from_rust_gather(stream_id, component_id, transmit)),
             GatherPoll::NewCandidate(cand) => {
                 Self::NewCandidate(Box::into_raw(Box::new(cand.into())))
             }

--- a/librice-proto/src/stream.rs
+++ b/librice-proto/src/stream.rs
@@ -623,14 +623,30 @@ impl StreamState {
                     }
                 }
                 GatherPoll::Complete => component.gather_state = GatherProgress::Completed,
-                GatherPoll::SendData(component_id, transmit) => {
-                    return Ok(GatherPoll::SendData(component_id, transmit.into_owned()))
+                GatherPoll::SendData {
+                    component_id,
+                    transmit,
+                } => {
+                    return Ok(GatherPoll::SendData {
+                        component_id,
+                        transmit: transmit.into_owned(),
+                    })
                 }
                 GatherPoll::NewCandidate(candidate) => {
                     return Ok(GatherPoll::NewCandidate(candidate))
                 }
-                GatherPoll::NeedAgent(component_id, transport, from, to) => {
-                    return Ok(GatherPoll::NeedAgent(component_id, transport, from, to))
+                GatherPoll::NeedAgent {
+                    component_id,
+                    transport,
+                    local_addr,
+                    remote_addr,
+                } => {
+                    return Ok(GatherPoll::NeedAgent {
+                        component_id,
+                        transport,
+                        local_addr,
+                        remote_addr,
+                    })
                 }
             }
         }

--- a/librice/src/stream.rs
+++ b/librice/src/stream.rs
@@ -138,7 +138,12 @@ impl futures::stream::Stream for Gather {
                     proto_stream.end_of_local_candidates();
                     return Poll::Ready(None);
                 }
-                Ok(GatherPoll::NeedAgent(component_id, transport, local_addr, server_addr)) => {
+                Ok(GatherPoll::NeedAgent {
+                    component_id,
+                    transport,
+                    local_addr,
+                    remote_addr: server_addr,
+                }) => {
                     if transport == TransportType::Tcp {
                         Stream::handle_gather_tcp_connect(
                             weak_stream.clone(),
@@ -157,7 +162,10 @@ impl futures::stream::Stream for Gather {
                     proto_stream.add_local_candidate(cand.clone());
                     return Poll::Ready(Some(cand));
                 }
-                Ok(GatherPoll::SendData(_component_id, transmit)) => {
+                Ok(GatherPoll::SendData {
+                    component_id: _,
+                    transmit,
+                }) => {
                     if let Err(async_std::channel::TrySendError::Full(transmit)) =
                         transmit_send.try_send(transmit.into_owned())
                     {


### PR DESCRIPTION
Provides more context as to what the values mean.  Especially when multiple values have the same type.