### PR TITLE
proto: add signalling for removing a socket from use

### DIFF
--- a/librice/tests/static_agent.rs
+++ b/librice/tests/static_agent.rs
@@ -189,8 +189,8 @@ async fn agent_static_connection_test(config: AgentStaticTestConfig) {
     assert_eq!(data, received);
     trace!("remote sent local received");
 
-    lagent.close().unwrap();
-    ragent.close().unwrap();
+    lagent.close();
+    ragent.close();
     trace!("agents closed");
 
     udp_abort_handle.abort();


### PR DESCRIPTION
Currently only used at close() time but will be expanded for removing sockets that are unused for the current connection.