### PR TITLE
rice-io: Use ERROR for default logging level

### DIFF
--- a/rice-io/src/capi.rs
+++ b/rice-io/src/capi.rs
@@ -38,7 +38,7 @@ fn init_logs() {
             .ok()
             .and_then(|var| var.parse::<tracing_subscriber::filter::Targets>().ok())
             .unwrap_or(
-                tracing_subscriber::filter::Targets::new().with_default(tracing::Level::TRACE),
+                tracing_subscriber::filter::Targets::new().with_default(tracing::Level::ERROR),
             );
         let registry = tracing_subscriber::registry().with(
             tracing_subscriber::fmt::layer()


### PR DESCRIPTION
Same as in rice-proto capi.